### PR TITLE
Decouple page getter from depaginator

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -36,7 +36,7 @@ type PagedData struct {
 	pageAhead   int      // Number of page requests to create
 }
 
-func (pd PagedData) GetPage(_ context.Context, depag *Depaginator[string], req PageRequest) ([]string, error) {
+func (pd PagedData) GetPage(_ context.Context, depag State, req PageRequest) ([]string, error) {
 	// First, update the items and pages
 	totalItems := 0
 	if pd.reportItems {

--- a/interfaces_test.go
+++ b/interfaces_test.go
@@ -28,7 +28,7 @@ type mockPageGetter struct {
 	mock.Mock
 }
 
-func (m *mockPageGetter) GetPage(ctx context.Context, depag *Depaginator[string], req PageRequest) ([]string, error) {
+func (m *mockPageGetter) GetPage(ctx context.Context, depag State, req PageRequest) ([]string, error) {
 	args := m.Called(ctx, depag, req)
 
 	return To[[]string](args.Get(0)), args.Error(1)


### PR DESCRIPTION
While writing an application using depaginator, I noted that it was going to be difficult to write tests for a page getter due to the GetPage routine being passed the actual depaginator.  The issue is that we can't easily create a depaginator object that can be used for testing, disconnected from an API, so the user would have to make a whole fake API just to test their page getter.

This change addresses this issue by abstracting the depaginator.  We create a State interface with the three methods that may be called from a PageGetter: Update, Request, and PerPage.  This then becomes the type that is passed to the GetPage method.  This doesn't require any code changes, as we can still pass the actual Depaginator object; but implementations of PageGetter can now create a mock for the State object and test their GetPage methods/functions in isolation.